### PR TITLE
Remove deprecated _type field

### DIFF
--- a/src/Logforwarding.js
+++ b/src/Logforwarding.js
@@ -120,7 +120,6 @@ function buildAction(logEvent, payload, index) {
   return {
     index: {
       _index: index,
-      _type: index,
       _id: logEvent.id
     }
   }


### PR DESCRIPTION
According to https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html, `_type` is no longer used.