### PR TITLE
Update NodeJS runtime to nodejs12.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "logs_to_elasticsearch" {
   function_name    = "${var.name_prefix}-LogsToElasticsearch"
   handler          = "Logforwarding.handler"
   role             = aws_iam_role.logs_to_elasticsearch_role.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   description      = "Sends logs from CloudWatch to AWS ElasticSearch Service"
   timeout          = "60"
   memory_size      = "128"


### PR DESCRIPTION
Vi fikk følgende feil når vi forsøkte å deploye med denne terraform modulen : 
Error: error creating Lambda Function: InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. 

Denne PR oppgraderer nodejs runtime til versjon 12.x