### PR TITLE
TCONTROL-2583: Add an alarm for failed invocations of the lambda function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,3 +96,21 @@ resource "aws_lambda_permission" "allow_invocation_from_logs" {
   principal = "logs.${data.aws_region.current.name}.amazonaws.com"
 }
 
+resource "aws_cloudwatch_metric_alarm" "elastic_index_is_full_alarm" {
+  count               = var.enable_alarm ? 1 : 0
+  alarm_name          = "${var.name_prefix}-logForwardLambdaFailedInvocations"
+  alarm_description   = "Alarm for failed invocations of the lambda function responsible for forwarding logs to elastic"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  statistic           = "Sum"
+  dimensions = {
+    FunctionName = aws_lambda_function.logs_to_elasticsearch.function_name
+  }
+  period              = var.period
+  evaluation_periods  = var.times_failed
+  threshold           = var.error_threshold
+  treat_missing_data  = var.treat_missing_data
+  alarm_actions       = var.alarm_sns_topic_arns
+  ok_actions          = var.alarm_sns_topic_arns
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,9 +27,49 @@ variable index {
   default     = "prm"
 }
 
+variable enable_alarm {
+    description = "Enable alarm for failed invocations of the lambda function"
+    default     = false
+
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)
   default     = {}
+}
+
+
+/*
+ * == Alarm Configuration
+ */
+variable "alarm_sns_topic_arns" {
+  description = "Where to send Alarms and OKs"
+  type        = list(string)
+}
+
+variable "error_threshold" {
+  description = "Amount of times the lambda can fail before an alarm is triggered"
+  type        = number
+  default     = 10
+}
+
+variable "times_failed" {
+  description = "Amount of elapsed evaluation periods before an alarm is triggered"
+  type        = number
+  default     = 1
+}
+
+variable "treat_missing_data" {
+  description = "How this alarm is to handle missing data points"
+  type        = string
+  default     = "missing"
+}
+
+
+variable "period" {
+  description = "Period in seconds to check for the applied statistic"
+  type        = number
+  default     = 300
 }
 


### PR DESCRIPTION
Jira: [TC-2583](https://vygruppen.atlassian.net/browse/TCONTROL-2583)

Vi bruker denne lambdaen til å sende logger til elastic, men vi fanger ikke opp feilene når den feiler mot Elastic på grunn av full index. Vi hadde en periode der vi plutselig ikke fikk sendt noe uten at det gikk noen alarm:
![image](https://github.com/nsbno/terraform-aws-elasticcloud/assets/47220032/a48c4966-62a6-47da-8680-498e66bb2f7b)

Legger derfor til denne alarmen som sjekker når vi har 10+ feilede lambda-kall.